### PR TITLE
Fix Patreon cookie parsing in login link API

### DIFF
--- a/app/api/vincular-login/route.ts
+++ b/app/api/vincular-login/route.ts
@@ -1,16 +1,16 @@
 // app/api/vincular-login/route.ts
 import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
 import { db } from "@/lib/firestore";
 
 export async function POST(req: Request) {
-  const body = await req.json();
-  const { loginUO } = body;
+  const { loginUO } = await req.json();
 
   if (!loginUO) {
     return NextResponse.json({ success: false, error: "Login ausente" }, { status: 400 });
   }
 
-  const patreonId = req.headers.get("cookie")?.match(/patreon_id=([^;]+)/)?.[1];
+  const patreonId = cookies().get("patreon_id")?.value;
 
   if (!patreonId) {
     return NextResponse.json({ success: false, error: "Usuário não autenticado" }, { status: 401 });


### PR DESCRIPTION
## Summary
- use Next.js `cookies()` helper instead of manual parsing in vincular-login route

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843917f0594832f9edf81578c6f2f97