### PR TITLE
Update cleanup logic to retain top scores

### DIFF
--- a/app/api/update-ironman-ranking/route.ts
+++ b/app/api/update-ironman-ranking/route.ts
@@ -34,9 +34,11 @@ export async function POST(req: NextRequest) {
       .where("PlayerName", "==", data.PlayerName)
       .get();
 
-    const sortedDocs = snapshot.docs.sort(
-      (a, b) => (b.data().Timestamp ?? 0) - (a.data().Timestamp ?? 0)
-    );
+    const sortedDocs = snapshot.docs.sort((a, b) => {
+      const scoreDiff = (b.data().Score ?? 0) - (a.data().Score ?? 0);
+      if (scoreDiff !== 0) return scoreDiff;
+      return (b.data().Timestamp ?? 0) - (a.data().Timestamp ?? 0);
+    });
 
     const docsToDelete = sortedDocs.slice(5);
     await Promise.all(docsToDelete.map((d) => d.ref.delete()));


### PR DESCRIPTION
## Summary
- adjust ranking cleanup logic to preserve a player's top 5 scores instead of the last 5 runs

## Testing
- `npm install`
- `npm run lint` *(fails: prompts for config)*

------
https://chatgpt.com/codex/tasks/task_e_684ffb30da18832f8f3fc22578fe369d