### PR TITLE
Fix mobile layout

### DIFF
--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -52,10 +52,18 @@
 .main {
   flex: 1;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   padding: 2rem 1rem;
   text-align: center;
+  gap: 2rem;
+}
+
+@media (min-width: 768px) {
+  .main {
+    flex-direction: row;
+  }
 }
   
 .intro h2 {


### PR DESCRIPTION
## Summary
- ensure home page sections stack vertically by default
- switch back to horizontal layout on screens wider than 768px

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npm run build` *(fails: Service account object must contain a string "project_id" property)*

------
https://chatgpt.com/codex/tasks/task_e_684ffeeba42c832f9869f8c187121d49