### PR TITLE
Implement SEO metadata and sitemap

### DIFF
--- a/app/ironman-ranking/page.tsx
+++ b/app/ironman-ranking/page.tsx
@@ -1,7 +1,15 @@
 "use client";
 import React, { useEffect, useState } from "react";
-import Head from "next/head";
 import styles from "../../styles/Home.module.css";
+import type { Metadata } from "next";
+import { defaultMetadata } from "@/lib/seo";
+
+export const metadata: Metadata = {
+  ...defaultMetadata,
+  title: "Ironman Ranking - UO Babel",
+  description:
+    "Ranking dos sobreviventes mais habilidosos do modo Ironman no servidor UO Babel.",
+};
 
 type IronmanRankingEntry = {
   PlayerName: string;
@@ -64,10 +72,6 @@ export default function IronmanRankingPage() {
 
   return (
     <div className={styles.container}>
-      <Head>
-        <title>Ironman Ranking - UO Babel</title>
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-      </Head>
       <main className="w-full max-w-4xl mx-auto p-6">
         <h1 className="text-3xl font-bold mb-6 text-center">🏆 Ironman Ranking</h1>
         <div className="overflow-x-auto rounded-lg shadow-lg">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,9 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
-import LegalBanner from "./components/LegalBanner"; // ou ajuste o caminho
+import LegalBanner from "./components/LegalBanner";
 import "./globals.css";
 import { Toaster } from "sonner";
+import { defaultMetadata } from "@/lib/seo";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -15,8 +16,7 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "UO Babel - Survival Hardcore",
-  description: "UO Babel - Survival Hardcore",
+  ...defaultMetadata,
 };
 
 export default function RootLayout({

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,10 +1,19 @@
 "use client";
 
-import Head from "next/head";
 import Image from "next/image";
 import styles from "../../styles/Home.module.css";
 import logo from "../../public/logo.png";
 import { useEffect } from "react";
+
+import type { Metadata } from "next";
+import { defaultMetadata } from "@/lib/seo";
+
+export const metadata: Metadata = {
+  ...defaultMetadata,
+  title: "Login com Patreon - UO Babel",
+  description:
+    "Conecte sua conta do Patreon para acessar recursos premium do servidor UO Babel.",
+};
 
 import { useRouter } from "next/navigation";
 export default function LoginPage() {
@@ -48,10 +57,6 @@ export default function LoginPage() {
 
   return (
     <div className={styles.container}>
-      <Head>
-        <title>Login com Patreon - UO Babel</title>
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-      </Head>
 
       <header className={styles.hero}>
         <div className={styles.heroContent}>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,18 +1,19 @@
 // pages/index.tsx
-import Head from "next/head";
 import Image from "next/image";
 import type { FC } from "react";
+import Link from "next/link";
+import { defaultMetadata } from "@/lib/seo";
+import type { Metadata } from "next";
 import styles from "../styles/Home.module.css";
 import logo from "../public/logo.png";
-import Link from "next/link";
+
+export const metadata: Metadata = {
+  ...defaultMetadata,
+};
 
 const Home: FC = () => {
   return (
     <div className={styles.container}>
-      <Head>
-        <title>UO Babel - Survival Hardcore</title>
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-      </Head>
 
       <header className={styles.hero}>
         <div className={styles.heroContent}>

--- a/app/painel/page.tsx
+++ b/app/painel/page.tsx
@@ -1,8 +1,16 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import Head from "next/head";
 import styles from "../../styles/Home.module.css";
+import type { Metadata } from "next";
+import { defaultMetadata } from "@/lib/seo";
+
+export const metadata: Metadata = {
+  ...defaultMetadata,
+  title: "Painel - UO Babel",
+  description:
+    "Gerencie seu acesso premium e vincule sua conta do Ultima Online no Painel do UO Babel.",
+};
 
 export default function PainelPage() {
   const [user, setUser] = useState<any>(null);
@@ -69,10 +77,6 @@ export default function PainelPage() {
 
   return (
     <div className={styles.container}>
-      <Head>
-        <title>Painel - UO Babel</title>
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-      </Head>
       <main className="max-w-xl mx-auto p-6 text-center">
         <h1 className="text-3xl font-bold mb-2">
           🎉 Bem-vindo, {user.fullName || "Patrono"}!

--- a/app/patreon/callback/page.tsx
+++ b/app/patreon/callback/page.tsx
@@ -4,6 +4,15 @@
 
 import { useEffect, useState, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import type { Metadata } from "next";
+import { defaultMetadata } from "@/lib/seo";
+
+export const metadata: Metadata = {
+  ...defaultMetadata,
+  title: "Callback do Patreon - UO Babel",
+  description:
+    "Processando autentica\u00e7\u00e3o do Patreon para liberar acesso no UO Babel.",
+};
 
 function CallbackInner() {
   const router = useRouter();

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,14 +1,18 @@
 // pages/privacy.tsx
-import Head from "next/head";
 import styles from "../../styles/Home.module.css";
+import type { Metadata } from "next";
+import { defaultMetadata } from "@/lib/seo";
+
+export const metadata: Metadata = {
+  ...defaultMetadata,
+  title: "Política de Privacidade - UO Babel",
+  description:
+    "Saiba como coletamos, usamos e protegemos seus dados no servidor UO Babel.",
+};
 
 export default function PrivacyPolicy() {
   return (
     <div className={styles.container}>
-      <Head>
-        <title>Política de Privacidade - UO Babel</title>
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-      </Head>
 
       <main className={styles.verticalPage}>
         <h1 className={styles.title}>Política de Privacidade</h1>

--- a/app/sitemap.xml/route.ts
+++ b/app/sitemap.xml/route.ts
@@ -1,0 +1,21 @@
+import { MetadataRoute } from "next";
+import { siteMetadata } from "@/lib/seo";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const pages = [
+    "",
+    "login",
+    "painel",
+    "ironman-ranking",
+    "terms",
+    "privacy",
+    "patreon/callback",
+  ];
+
+  const urls = pages.map((p) => ({
+    url: `${siteMetadata.siteUrl}/${p}`.replace(/\/$/, ""),
+    lastModified: new Date(),
+  }));
+
+  return urls;
+}

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,14 +1,18 @@
 // pages/terms.tsx
-import Head from "next/head";
 import styles from "../../styles/Home.module.css";
+import type { Metadata } from "next";
+import { defaultMetadata } from "@/lib/seo";
+
+export const metadata: Metadata = {
+  ...defaultMetadata,
+  title: "Termos de Uso - UO Babel",
+  description:
+    "Condi\u00e7\u00f5es de uso para aproveitar o servidor de Ultima Online UO Babel.",
+};
 
 export default function TermsOfService() {
   return (
     <div className={styles.container}>
-      <Head>
-        <title>Termos de Uso - UO Babel</title>
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-      </Head>
 
       <main className={styles.verticalPage}>
         <h1 className={styles.title}>Termos de Uso</h1>

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -1,0 +1,42 @@
+import type { Metadata } from "next";
+
+export const siteMetadata = {
+  title: "UO Babel - Survival Hardcore",
+  description:
+    "Servidor de Ultima Online focado em sobreviv\u00eancia hardcore com conte\u00fado exclusivo.",
+  siteUrl: "https://www.uobabel.com",
+};
+
+export const defaultOpenGraph = {
+  title: siteMetadata.title,
+  description: siteMetadata.description,
+  url: siteMetadata.siteUrl,
+  siteName: "UO Babel",
+  images: [
+    {
+      url: `${siteMetadata.siteUrl}/Banner.png`,
+      width: 1200,
+      height: 630,
+      alt: "UO Babel Banner",
+    },
+  ],
+  locale: "pt_BR",
+  type: "website" as const,
+};
+
+export const defaultMetadata: Metadata = {
+  title: siteMetadata.title,
+  description: siteMetadata.description,
+  metadataBase: new URL(siteMetadata.siteUrl),
+  openGraph: defaultOpenGraph,
+  viewport: {
+    width: "device-width",
+    initialScale: 1,
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: siteMetadata.title,
+    description: siteMetadata.description,
+    images: [`${siteMetadata.siteUrl}/Banner.png`],
+  },
+};

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://www.uobabel.com/sitemap.xml


### PR DESCRIPTION
## Summary
- create a SEO helper with default metadata
- wire default metadata in the site layout
- add SEO metadata to all pages
- provide `robots.txt` and dynamic `sitemap.xml`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: interactive configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_6850012a284c832f869955db760735eb