### PR TITLE
Fix ranking client to parse api response

### DIFF
--- a/app/ironman-ranking/IronmanClient.tsx
+++ b/app/ironman-ranking/IronmanClient.tsx
@@ -52,7 +52,10 @@ export default function IronmanClient() {
     fetch("/api/ironman-ranking")
       .then((res) => res.json())
       .then((data) => {
-        setRanking(data.ranking);
+        // The API may return the ranking array directly or inside a
+        // `ranking` property. Handle both for backwards compatibility.
+        const entries = Array.isArray(data) ? data : data.ranking;
+        setRanking(entries);
         setLoading(false);
       })
       .catch(() => {


### PR DESCRIPTION
## Summary
- fix Ironman ranking loader by accepting API array or object

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68500ca4960c832fa3a38d31ec689283