### PR TITLE
Improve painel and ranking layout

### DIFF
--- a/app/ironman-ranking/IronmanClient.tsx
+++ b/app/ironman-ranking/IronmanClient.tsx
@@ -78,10 +78,10 @@ export default function IronmanClient() {
 
   return (
     <div className={styles.container}>
-      <main className={styles.main}>
+      <main className="flex flex-col items-center w-full max-w-2xl mx-auto p-6">
         <h1 className="text-2xl font-bold mb-4">Ironman Ranking</h1>
         <div className="overflow-x-auto">
-          <table className="min-w-full border border-gray-300">
+          <table className="min-w-full w-full text-sm border border-gray-300">
             <thead>
               <tr>
                 <th className="px-4 py-2">Jogador</th>

--- a/app/painel/ClientPage.tsx
+++ b/app/painel/ClientPage.tsx
@@ -65,7 +65,7 @@ export default function ClientPage() {
 
   return (
     <div className={styles.container}>
-      <main className={styles.main}>
+      <main className="flex flex-col items-center w-full max-w-md mx-auto p-6">
         <h1 className="text-2xl font-bold mb-4">Painel do Usuário</h1>
         <p className="mb-4">Olá, {user.fullName}!</p>
         <div className="mb-4">


### PR DESCRIPTION
## Summary
- make painel layout vertical and centered
- center ranking page and make table responsive

## Testing
- `npm run lint` *(fails: configuration prompts)*
- `npm run build` *(fails: missing Firebase environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68501052ebbc832f98d590b8ca2b9cf2