### PR TITLE
Fix mobile ranking layout

### DIFF
--- a/app/ironman-ranking/IronmanClient.tsx
+++ b/app/ironman-ranking/IronmanClient.tsx
@@ -78,7 +78,7 @@ export default function IronmanClient() {
 
   return (
     <div className={styles.container}>
-      <main className="flex flex-col items-center w-full max-w-2xl mx-auto p-6">
+      <main className="flex flex-col items-start w-full max-w-2xl mx-auto p-6">
         <h1 className="text-2xl font-bold mb-4">Ironman Ranking</h1>
         <div className="overflow-x-auto overflow-y-auto max-h-[70vh]">
           <table className="min-w-full w-full text-sm border border-gray-300">


### PR DESCRIPTION
## Summary
- prevent horizontal overflow on the ranking page by aligning content to the left

## Testing
- `npm run lint` *(fails: prompts for interactive config)*

------
https://chatgpt.com/codex/tasks/task_e_6850144cff54832fb1805247a067c9f6