### PR TITLE
Fix ranking background overflow

### DIFF
--- a/app/ironman-ranking/IronmanClient.tsx
+++ b/app/ironman-ranking/IronmanClient.tsx
@@ -80,7 +80,7 @@ export default function IronmanClient() {
     <div className={styles.container}>
       <main className="flex flex-col items-start w-full max-w-2xl mx-auto p-6">
         <h1 className="text-2xl font-bold mb-4">Ironman Ranking</h1>
-        <div className="overflow-x-auto overflow-y-auto max-h-[70vh]">
+        <div className="overflow-x-auto">
           <table className="min-w-full w-full text-sm border border-gray-300">
             <thead>
               <tr>


### PR DESCRIPTION
## Summary
- ironman ranking page shouldn't have internal vertical scroll - remove `max-h-[70vh]` so the container grows with the table

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685017f14344832f9b345a87ed5bd9bd