### PR TITLE
Fix ranking page background stretch

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -19,7 +19,9 @@
   }
 }
 
+html,
 body {
+  min-height: 100%;
   background: var(--background);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -1,5 +1,6 @@
 .container {
-  min-height: 100vh;
+  min-height: 100%;
+  min-height: 100dvh;
   display: flex;
   flex-direction: column;
   background: linear-gradient(180deg, #0d0d0d, #1e1e1e 40%, #1c0f2b);


### PR DESCRIPTION
## Summary
- tweak global styles so body can stretch with content
- allow container background to expand using dynamic viewport

## Testing
- `npm run lint` *(fails: prompt for ESLint setup)*
- `npm run build` *(fails: Service account object must contain a string "project_id" property)*

------
https://chatgpt.com/codex/tasks/task_e_68501a45f318832fbcc35079678d2b32