### PR TITLE
Implement Firestore auth endpoints

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/lib/firestore";
+
+interface LoginRequest {
+  Email: string;
+  Password: string;
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const { Email, Password } = (await req.json()) as Partial<LoginRequest>;
+
+    if (!Email || !Password) {
+      return NextResponse.json(
+        { success: false, error: "Dados incompletos." },
+        { status: 400 }
+      );
+    }
+
+    const snapshot = await db
+      .collection("users")
+      .where("Email", "==", Email)
+      .where("Password", "==", Password)
+      .get();
+
+    if (snapshot.empty) {
+      return NextResponse.json(
+        { success: false, error: "Credenciais inválidas." },
+        { status: 401 }
+      );
+    }
+
+    const doc = snapshot.docs[0];
+    const userData = doc.data();
+
+    return NextResponse.json({ success: true, user: { id: doc.id, ...userData } });
+  } catch (err: any) {
+    console.error("Erro ao fazer login:", err);
+    return NextResponse.json(
+      { success: false, error: "Erro interno", details: err.message },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/lib/firestore";
+
+interface RegisterRequest {
+  Email: string;
+  Username: string;
+  Password: string;
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const { Email, Username, Password } = (await req.json()) as Partial<RegisterRequest>;
+
+    if (!Email || !Username || !Password) {
+      return NextResponse.json(
+        { success: false, error: "Dados incompletos." },
+        { status: 400 }
+      );
+    }
+
+    const existing = await db
+      .collection("users")
+      .where("Email", "==", Email)
+      .get();
+
+    if (!existing.empty) {
+      return NextResponse.json(
+        { success: false, error: "Email já registrado." },
+        { status: 409 }
+      );
+    }
+
+    await db.collection("users").add({
+      Email,
+      Username,
+      Password,
+      createdAt: Date.now(),
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (err: any) {
+    console.error("Erro ao registrar usuário:", err);
+    return NextResponse.json(
+      { success: false, error: "Erro interno", details: err.message },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- implement `/api/auth/register` for registering user documents
- implement `/api/auth/login` for simple credential checks

## Testing
- `npm install`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_686bd2fdac38832f98866c49204053b8