### PR TITLE
Implement register_ingame route

### DIFF
--- a/app/api/auth/register_ingame/route.ts
+++ b/app/api/auth/register_ingame/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/lib/firestore";
+import admin from "firebase-admin";
+
+interface RegisterIngameRequest {
+  Email: string;
+  Username: string;
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const { Email, Username } = (await req.json()) as Partial<RegisterIngameRequest>;
+
+    if (!Email || !Username) {
+      return NextResponse.json(
+        { success: false, error: "Dados incompletos." },
+        { status: 400 }
+      );
+    }
+
+    const snapshot = await db.collection("users").where("Email", "==", Email).get();
+
+    if (snapshot.empty) {
+      return NextResponse.json(
+        { success: false, error: "Usuário não encontrado." },
+        { status: 404 }
+      );
+    }
+
+    const doc = snapshot.docs[0];
+    const data = doc.data();
+    const usernames: string[] = Array.isArray(data.Usernames) ? data.Usernames : [];
+
+    if (usernames.length >= 3) {
+      return NextResponse.json(
+        { success: false, error: "Usernames já preenchidos." },
+        { status: 409 }
+      );
+    }
+
+    await doc.ref.update({
+      Usernames: admin.firestore.FieldValue.arrayUnion(Username),
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (err: any) {
+    console.error("Erro ao registrar username ingame:", err);
+    return NextResponse.json(
+      { success: false, error: "Erro interno", details: err.message },
+      { status: 500 }
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- implement register_ingame route to allow storing up to three usernames for a user

## Testing
- `npm install`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_686c1a75d7c0832faae3100851c37bce